### PR TITLE
Enable SSE4.1 and AVX flags on UNIX builds to fix intrinsic inlining errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,12 @@ if(TB_ENABLE_ASAN)
   endif()
 endif()
 
+# Enable SSE4.1 and AVX support for intrinsics (e.g., _mm_blendv_ps) to avoid errors on Linux
+if(UNIX)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.1")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx")
+endif()
+
 include(cmake/Utils.cmake)
 
 # Find Git


### PR DESCRIPTION
This change adds the -msse4.1 and -mavx compiler flags for UNIX builds. These flags enable the necessary instruction set support for intrinsics like _mm_blendv_ps, which previously led to inlining errors due to a target-specific option mismatch. By adding these flags, we ensure that the compiler generates code with proper support for SSE4.1 and AVX instructions, thus resolving the compilation issues.

Errors:
```
In file included from /usr/lib/gcc/x86_64-linux-gnu/12/include/immintrin.h:39,
                 from /var/dev/TrenchBroomBFG/lib/tinybvh/include/tiny_bvh.h:110,
                 from /var/dev/TrenchBroomBFG/lib/tinybvh/src/tiny_bvh_impl.cpp:3:
/usr/lib/gcc/x86_64-linux-gnu/12/include/smmintrin.h: In member function ‘int32_t tinybvh::BVH4_CPU::Intersect(tinybvh::Ray&) const’:
/usr/lib/gcc/x86_64-linux-gnu/12/include/smmintrin.h:204:1: error: inlining failed in call to ‘always_inline’ ‘__m128 _mm_blendv_ps(__m128, __m128, __m128)’: target specific option mismatch
  204 | _mm_blendv_ps (__m128 __X, __m128 __Y, __m128 __M)
```