### PR TITLE
Building on Apple Silicion MacOS version 15.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ if(TB_ENABLE_ASAN)
 endif()
 
 # Enable SSE4.1 and AVX support for intrinsics (e.g., _mm_blendv_ps) to avoid errors on Linux
-if(UNIX)
+if(UNIX AND (NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64"))
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.1")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx")
 endif()

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1021,7 +1021,8 @@ set(COMMON_HEADER
 add_library(common OBJECT ${COMMON_SOURCE} ${COMMON_HEADER})
 set_target_properties(common PROPERTIES AUTOMOC TRUE)
 target_include_directories(common PUBLIC ${COMMON_SOURCE_DIR})
-target_link_libraries(common PUBLIC tinyxml2::tinyxml2 kdl vecmath GLEW::GLEW miniz::miniz freeimage::FreeImage freetype OpenGL::GL Qt5::Widgets Qt5::Svg fmt::fmt assimp::assimp tinybvh)
+target_link_libraries(common PUBLIC tinyxml2::tinyxml2 kdl vecmath GLEW::GLEW freeimage::FreeImage freetype OpenGL::GL Qt5::Widgets Qt5::Svg fmt::fmt assimp::assimp tinybvh)
+target_link_libraries(common PRIVATE miniz::miniz)
 
 # use precompiled headers on CMake 3.16 or later
 if (NOT TB_SUPPRESS_PCH AND ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16.0")

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -37,6 +37,11 @@
       "name": "tinyxml2",
       "version>=": "9.0.0",
       "platform": "!linux"
+    },
+    {
+      "name": "libpng",
+      "version>=": "1.6.47#0",
+      "platform": "!linux"
     }
   ],
   "builtin-baseline": "13bde2ff13192e1b2fdd37bd9b475c7665ae6ae5",


### PR DESCRIPTION
Two changes:

First one forces latest `libpng` dependency version to fix missing "fp.h" include on Mac: [libpng/pull/529](https://github.com/pnggroup/libpng/pull/529)

Second one omits AVX and SSE flags for ARM64 since those extensions are unsupported.

This allows me to generate the `.xcodeproj` and build it, but it fails on linking phase due to `kubazip` and `miniz` conflict (possibly?). I get `115 duplicate symbols` in Xcode and the following log (shortened):

```
ld: warning: ignoring duplicate libraries: '/Users/julian/Projects/TrenchBroomBFG/build-xcode/vcpkg_installed/arm64-osx/lib/libjasper.a', '/Users/julian/Projects/TrenchBroomBFG/build-xcode/vcpkg_installed/arm64-osx/lib/libjpeg.a', '/Users/julian/Projects/TrenchBroomBFG/build-xcode/vcpkg_installed/arm64-osx/lib/libjpegxr.a', '/Users/julian/Projects/TrenchBroomBFG/build-xcode/vcpkg_installed/arm64-osx/lib/libjxrglue.a', '/Users/julian/Projects/TrenchBroomBFG/build-xcode/vcpkg_installed/arm64-osx/lib/liblzma.a', '/Users/julian/Projects/TrenchBroomBFG/build-xcode/vcpkg_installed/arm64-osx/lib/libtiff.a', '/Users/julian/Projects/TrenchBroomBFG/build-xcode/vcpkg_installed/arm64-osx/lib/libz.a', '/Users/julian/Projects/TrenchBroomBFG/build-xcode/vcpkg_installed/arm64-osx/lib/manual-link/libraw.a'
duplicate symbol '_mz_zip_reader_extract_iter_read' in:
    /Users/user/Projects/TrenchBroomBFG/build-xcode/vcpkg_installed/arm64-osx/lib/libminiz.a[3](miniz_zip.c.o)
    /Users/user/Projects/TrenchBroomBFG/build-xcode/vcpkg_installed/arm64-osx/lib/libkubazip.a[2](zip.c.o)
...
duplicate symbol '_mz_zip_clear_last_error' in:
    /Users/user/Projects/TrenchBroomBFG/build-xcode/vcpkg_installed/arm64-osx/lib/libminiz.a[3](miniz_zip.c.o)
    /Users/user/Projects/TrenchBroomBFG/build-xcode/vcpkg_installed/arm64-osx/lib/libkubazip.a[2](zip.c.o)
```

A help would be appreciated.
Thanks!